### PR TITLE
Generate constexpr sml

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,6 +9,7 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
+            "elm-community/list-extra": "8.7.0",
             "lukewestby/elm-string-interpolate": "1.0.4"
         },
         "indirect": {

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -89,8 +89,9 @@ makeSystemNameInput model =
 makeCodeOutput: Model -> Html msg
 makeCodeOutput model =
     let
-        cppStr =makeFsmRowTable model.tableData
-               |> make_cpp_data model.systemName
+        smlClass = Cpp.makeConstexprClass model.tableData
+        cppStr = makeFsmRowTable model.tableData
+               |> make_cpp_data  smlClass model.systemName
                |> text
 
     in


### PR DESCRIPTION
Generates the constexpr statement for states .

`constexpr static auto {state} = sml::state<class {state]>`

